### PR TITLE
Fix Clone & Run from Lightning App Gallery

### DIFF
--- a/echo/utils/frontend.py
+++ b/echo/utils/frontend.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from urllib.request import urlretrieve
+
+urls = [
+    "https://storage.googleapis.com/lightning-echo-prod/build/asset-manifest.json",
+    "https://storage.googleapis.com/lightning-echo-prod/build/echo-logo-text.svg",
+    "https://storage.googleapis.com/lightning-echo-prod/build/echo-preview.png",
+    "https://storage.googleapis.com/lightning-echo-prod/build/favicon.svg",
+    "https://storage.googleapis.com/lightning-echo-prod/build/index.html",
+    "https://storage.googleapis.com/lightning-echo-prod/build/manifest.json",
+    "https://storage.googleapis.com/lightning-echo-prod/build/robots.txt",
+]
+
+
+def download_frontend_build(destination: Path):
+    for url in urls:
+        file = Path(url.split("/")[-1])
+        urlretrieve(url, destination / file)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

The frontend JavaScript build files need to be fetched at runtime because they are not committed to the app git repository (which they shouldn't be).

This only affects 'Clone & Run' because the production deployment to lightning.ai/echo uses the GitHub Action, which includes the frontend files as part of its build step.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
