### PR TITLE
downgrade lightning and add pyparsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lightning==1.8.4
+lightning==1.8.0.post1
 sqlmodel==0.0.8
 pydantic==1.10.2
 uvicorn==0.18.3
@@ -11,3 +11,4 @@ python-magic==0.4.27
 pysrt==1.1.2
 ffmpeg-python==0.2.0
 youtube_dl==2021.12.17
+pyparsing>=3.0.0


### PR DESCRIPTION
we suspected the upgrade to 1.8.4 broke things, but downgrading to 1.8.0 and fixing pyparsing doesn't bring echo back

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
